### PR TITLE
:spark: clone workouts and circuits

### DIFF
--- a/app/Actions/Admin/CloneBookingSlotCircuit.php
+++ b/app/Actions/Admin/CloneBookingSlotCircuit.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Actions\Admin;
+
+use App\Models\BookingSlot;
+use App\Models\BookingSlotCircuit;
+use Illuminate\Support\Facades\DB;
+
+class CloneBookingSlotCircuit
+{
+    public function handle(BookingSlotCircuit $sourceCircuit, BookingSlot $targetBookingSlot): void
+    {
+        DB::transaction(function () use ($sourceCircuit, $targetBookingSlot) {
+            $circuitCount = $targetBookingSlot->circuits()->count();
+            /** @var BookingSlotCircuit $targetCircuit */
+            $targetCircuit = $targetBookingSlot->circuits()->create([
+                'name' => $sourceCircuit->name ?? 'Circuit '.($circuitCount + 1),
+            ]);
+
+            foreach ($sourceCircuit->circuitWorkouts()->with('sets')->get() as $sourceWorkout) {
+                app(CreateBookingSlotCircuitWorkout::class)->handle($targetCircuit, [
+                    'workout_id' => $sourceWorkout->workout_id,
+                    'notes' => $sourceWorkout->notes,
+                    'sets' => $sourceWorkout->sets->map(fn ($set) => [
+                        'reps' => $set->reps,
+                        'weight_in_kg' => $set->weight_in_kg,
+                        'duration_in_seconds' => $set->duration_in_seconds,
+                    ])->all(),
+                ]);
+            }
+        });
+    }
+}

--- a/app/Actions/Admin/CloneBookingSlotCircuitWorkout.php
+++ b/app/Actions/Admin/CloneBookingSlotCircuitWorkout.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Actions\Admin;
+
+use App\Models\BookingSlotCircuit;
+use App\Models\BookingSlotCircuitWorkout;
+
+class CloneBookingSlotCircuitWorkout
+{
+    public function handle(BookingSlotCircuitWorkout $sourceWorkout, BookingSlotCircuit $targetCircuit): void
+    {
+        app(CreateBookingSlotCircuitWorkout::class)->handle($targetCircuit, [
+            'workout_id' => $sourceWorkout->workout_id,
+            'notes' => $sourceWorkout->notes,
+            'sets' => $sourceWorkout->sets->map(fn ($set) => [
+                'reps' => $set->reps,
+                'weight_in_kg' => $set->weight_in_kg,
+                'duration_in_seconds' => $set->duration_in_seconds,
+            ])->all(),
+        ]);
+    }
+}

--- a/app/Enums/Category.php
+++ b/app/Enums/Category.php
@@ -19,6 +19,7 @@ enum Category: string
     case Training = 'Training';
     case Stability = 'Stability';
     case Mobility = 'Mobility';
+    case Arms = 'Arms';
 
     /**
      * Get all enum case values as an array of strings.

--- a/app/Http/Controllers/Admin/CloneBookingSlotCircuitController.php
+++ b/app/Http/Controllers/Admin/CloneBookingSlotCircuitController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Actions\Admin\CloneBookingSlotCircuit;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\CloneBookingSlotCircuitRequest;
+use App\Models\BookingSlot;
+use App\Models\BookingSlotCircuit;
+use Illuminate\Http\RedirectResponse;
+
+class CloneBookingSlotCircuitController extends Controller
+{
+    public function __invoke(CloneBookingSlotCircuitRequest $request, BookingSlot $bookingSlot, CloneBookingSlotCircuit $cloneBookingSlotCircuit): RedirectResponse
+    {
+        $sourceCircuit = BookingSlotCircuit::query()->findOrFail($request->integer('source_circuit_id'));
+
+        $cloneBookingSlotCircuit->handle($sourceCircuit, $bookingSlot);
+
+        return redirect()->back()
+            ->with('flash.banner', 'Circuit cloned successfully')
+            ->with('flash.bannerStyle', 'success');
+    }
+}

--- a/app/Http/Controllers/Admin/CloneBookingSlotCircuitWorkoutController.php
+++ b/app/Http/Controllers/Admin/CloneBookingSlotCircuitWorkoutController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Actions\Admin\CloneBookingSlotCircuitWorkout;
+use App\Actions\Admin\CreateBookingSlotCircuit;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\CloneBookingSlotCircuitWorkoutRequest;
+use App\Models\BookingSlot;
+use App\Models\BookingSlotCircuit;
+use App\Models\BookingSlotCircuitWorkout;
+use Illuminate\Http\RedirectResponse;
+
+class CloneBookingSlotCircuitWorkoutController extends Controller
+{
+    public function __invoke(
+        CloneBookingSlotCircuitWorkoutRequest $request,
+        BookingSlot $bookingSlot,
+        CloneBookingSlotCircuitWorkout $cloneBookingSlotCircuitWorkout,
+        CreateBookingSlotCircuit $createBookingSlotCircuit,
+    ): RedirectResponse {
+        $sourceWorkout = BookingSlotCircuitWorkout::with('sets')->findOrFail($request->integer('source_workout_id'));
+
+        if ($request->filled('circuit_id')) {
+            $targetCircuit = BookingSlotCircuit::query()->findOrFail($request->integer('circuit_id'));
+        } else {
+            $createBookingSlotCircuit->handle($bookingSlot, []);
+            $targetCircuit = $bookingSlot->circuits()->latest()->first();
+        }
+
+        $cloneBookingSlotCircuitWorkout->handle($sourceWorkout, $targetCircuit);
+
+        return redirect()->back()
+            ->with('flash.banner', 'Workout cloned successfully')
+            ->with('flash.bannerStyle', 'success');
+    }
+}

--- a/app/Http/Requests/Admin/CloneBookingSlotCircuitRequest.php
+++ b/app/Http/Requests/Admin/CloneBookingSlotCircuitRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CloneBookingSlotCircuitRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'source_circuit_id' => ['required', 'integer', 'exists:booking_slot_circuits,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/CloneBookingSlotCircuitWorkoutRequest.php
+++ b/app/Http/Requests/Admin/CloneBookingSlotCircuitWorkoutRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CloneBookingSlotCircuitWorkoutRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'source_workout_id' => ['required', 'integer', 'exists:booking_slot_circuit_workouts,id'],
+            'circuit_id' => ['nullable', 'integer', 'exists:booking_slot_circuits,id'],
+        ];
+    }
+}

--- a/resources/js/Pages/Admin/BookingsSlots/Partials/BookingSlotHeader.vue
+++ b/resources/js/Pages/Admin/BookingsSlots/Partials/BookingSlotHeader.vue
@@ -45,6 +45,7 @@
         <PreviousSessionsModal
             :show="showPreviousSessionsModal"
             :booking-slot-id="id"
+            :current-circuits="bookingSlot.circuits || []"
             @close="showPreviousSessionsModal = false"
         />
     </div>

--- a/resources/js/Pages/Admin/BookingsSlots/Partials/CloneWorkoutModal.vue
+++ b/resources/js/Pages/Admin/BookingsSlots/Partials/CloneWorkoutModal.vue
@@ -1,0 +1,119 @@
+<template>
+    <Modal :show="show" @close="$emit('close')" max-width="md">
+        <div class="space-y-4">
+            <h2 class="text-lg font-medium text-zinc-900">Clone workout</h2>
+
+            <div v-if="workout" class="text-sm text-zinc-600">
+                Cloning <span class="font-medium text-zinc-900">{{ workout.name }}</span>
+            </div>
+
+            <div v-if="currentCircuits.length > 0" class="space-y-2">
+                <p class="text-sm text-zinc-700 font-medium">Add to circuit:</p>
+                <div class="space-y-2">
+                    <label
+                        v-for="circuit in currentCircuits"
+                        :key="circuit.id"
+                        class="flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors"
+                        :class="selectedCircuitId === circuit.id ? 'border-zinc-900 bg-zinc-50' : 'border-zinc-200 hover:border-zinc-300'"
+                    >
+                        <input
+                            type="radio"
+                            :value="circuit.id"
+                            v-model="selectedCircuitId"
+                            class="accent-zinc-900"
+                        />
+                        <span class="text-sm text-zinc-800">{{ circuit.name }}</span>
+                    </label>
+                    <label
+                        class="flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors"
+                        :class="selectedCircuitId === null ? 'border-zinc-900 bg-zinc-50' : 'border-zinc-200 hover:border-zinc-300'"
+                    >
+                        <input
+                            type="radio"
+                            :value="null"
+                            v-model="selectedCircuitId"
+                            class="accent-zinc-900"
+                        />
+                        <span class="text-sm text-zinc-800">New circuit</span>
+                    </label>
+                </div>
+            </div>
+
+            <div v-else class="text-sm text-zinc-500">
+                A new circuit will be created for this workout.
+            </div>
+        </div>
+
+        <template #footer>
+            <div class="flex gap-2">
+                <button
+                    type="button"
+                    @click="$emit('close')"
+                    class="inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-zinc-900 shadow-sm ring-1 ring-inset ring-zinc-300 hover:bg-zinc-50 sm:w-auto cursor-pointer transition ease-in-out duration-150"
+                >
+                    Cancel
+                </button>
+                <button
+                    type="button"
+                    @click="submit"
+                    :disabled="processing"
+                    class="inline-flex w-full justify-center rounded-md bg-zinc-900 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-zinc-800 active:bg-zinc-950 sm:w-auto cursor-pointer transition ease-in-out duration-150 disabled:opacity-50"
+                >
+                    {{ processing ? 'Cloning...' : 'Clone workout' }}
+                </button>
+            </div>
+        </template>
+    </Modal>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { router } from '@inertiajs/vue3'
+import Modal from '@/Components/Layout/Modal.vue'
+
+const props = defineProps({
+    show: { type: Boolean, required: true },
+    workout: { type: Object, default: null },
+    currentCircuits: { type: Array, default: () => [] },
+    bookingSlotId: { type: Number, required: true },
+})
+
+const emit = defineEmits(['close', 'cloned'])
+
+const selectedCircuitId = ref(null)
+const processing = ref(false)
+
+// Default to first circuit when opening, if any exist
+watch(() => props.show, (newValue) => {
+    if (newValue && props.currentCircuits.length > 0) {
+        selectedCircuitId.value = props.currentCircuits[0].id
+    } else {
+        selectedCircuitId.value = null
+    }
+})
+
+const submit = () => {
+    if (!props.workout) {
+        return
+    }
+
+    processing.value = true
+
+    router.post(
+        route('admin.bookings-slots.clone-circuit-workout', { bookingSlot: props.bookingSlotId }),
+        {
+            source_workout_id: props.workout.id,
+            circuit_id: selectedCircuitId.value,
+        },
+        {
+            onSuccess: () => {
+                emit('cloned')
+                emit('close')
+            },
+            onFinish: () => {
+                processing.value = false
+            },
+        }
+    )
+}
+</script>

--- a/resources/js/Pages/Admin/BookingsSlots/Partials/PreviousSessionsModal.vue
+++ b/resources/js/Pages/Admin/BookingsSlots/Partials/PreviousSessionsModal.vue
@@ -52,6 +52,8 @@
                                 v-for="circuit in session.circuits"
                                 :key="circuit.id"
                                 :circuit="circuit"
+                                @clone-circuit="handleCloneCircuit"
+                                @clone-workout="handleCloneWorkout"
                             />
                         </div>
 
@@ -64,18 +66,30 @@
             </div>
         </div>
     </Modal>
+
+    <CloneWorkoutModal
+        :show="showCloneWorkoutModal"
+        :workout="workoutToClone"
+        :current-circuits="currentCircuits"
+        :booking-slot-id="bookingSlotId"
+        @close="showCloneWorkoutModal = false"
+        @cloned="handleClose"
+    />
 </template>
 
 <script setup>
 import { ref, watch, computed } from 'vue'
+import { router } from '@inertiajs/vue3'
 import { CalendarIcon, ClockIcon } from '@heroicons/vue/24/outline'
 import Modal from '@/Components/Layout/Modal.vue'
 import ReadOnlyCircuitColumn from './ReadOnlyCircuitColumn.vue'
+import CloneWorkoutModal from './CloneWorkoutModal.vue'
 
 const props = defineProps({
     show: { type: Boolean, required: true },
     bookingSlotId: { type: Number, required: true },
     limit: { type: Number, default: 2 },
+    currentCircuits: { type: Array, default: () => [] },
 })
 
 const emit = defineEmits(['close'])
@@ -85,6 +99,8 @@ const previousSessions = ref([])
 const selectedLimit = ref(3)
 const contentContainer = ref(null)
 const lockedHeight = ref(null)
+const showCloneWorkoutModal = ref(false)
+const workoutToClone = ref(null)
 
 const containerStyle = computed(() => {
     return lockedHeight.value ? { minHeight: `${lockedHeight.value}px` } : {}
@@ -120,6 +136,19 @@ const fetchPreviousSessions = async () => {
 
 const handleClose = () => {
     emit('close')
+}
+
+const handleCloneCircuit = (circuit) => {
+    router.post(
+        route('admin.bookings-slots.clone-circuit', { bookingSlot: props.bookingSlotId }),
+        { source_circuit_id: circuit.id },
+        { onSuccess: () => handleClose() }
+    )
+}
+
+const handleCloneWorkout = (workout) => {
+    workoutToClone.value = workout
+    showCloneWorkoutModal.value = true
 }
 
 // Fetch data when modal opens

--- a/resources/js/Pages/Admin/BookingsSlots/Partials/ReadOnlyCircuitColumn.vue
+++ b/resources/js/Pages/Admin/BookingsSlots/Partials/ReadOnlyCircuitColumn.vue
@@ -2,8 +2,16 @@
     <div class="flex flex-col w-full md:w-[30%] md:min-w-[300px] md:flex-shrink-0 md:h-full">
         <!-- Circuit Header (Read-Only) -->
         <div class="bg-zinc-50 rounded-lg p-3">
-            <div class="px-2 py-1 font-medium text-zinc-800">
-                {{ circuit.name }}
+            <div class="flex items-center justify-between px-2 py-1">
+                <span class="font-medium text-zinc-800">{{ circuit.name }}</span>
+                <button
+                    type="button"
+                    @click="$emit('clone-circuit', circuit)"
+                    class="p-1 rounded hover:bg-zinc-200 text-zinc-400 hover:text-zinc-600 transition-colors cursor-pointer"
+                    title="Clone circuit"
+                >
+                    <DocumentDuplicateIcon class="w-4 h-4" />
+                </button>
             </div>
         </div>
 
@@ -14,6 +22,7 @@
                 v-for="workout in circuit.workouts"
                 :key="workout.id"
                 :workout="workout"
+                @clone-workout="$emit('clone-workout', $event)"
             />
 
             <!-- Empty State -->
@@ -25,9 +34,12 @@
 </template>
 
 <script setup>
+import { DocumentDuplicateIcon } from '@heroicons/vue/24/outline'
 import ReadOnlyCircuitWorkoutCard from './ReadOnlyCircuitWorkoutCard.vue'
 
 defineProps({
     circuit: { type: Object, required: true },
 })
+
+defineEmits(['clone-circuit', 'clone-workout'])
 </script>

--- a/resources/js/Pages/Admin/BookingsSlots/Partials/ReadOnlyCircuitWorkoutCard.vue
+++ b/resources/js/Pages/Admin/BookingsSlots/Partials/ReadOnlyCircuitWorkoutCard.vue
@@ -14,6 +14,14 @@
                     </span>
                 </div>
             </div>
+            <button
+                type="button"
+                @click="$emit('clone-workout', workout)"
+                class="ml-2 flex-shrink-0 p-1 rounded hover:bg-zinc-100 text-zinc-400 hover:text-zinc-600 transition-colors cursor-pointer"
+                title="Clone workout"
+            >
+                <DocumentDuplicateIcon class="w-4 h-4" />
+            </button>
         </div>
 
         <!-- Sets Display -->
@@ -35,9 +43,13 @@
 </template>
 
 <script setup>
+import { DocumentDuplicateIcon } from '@heroicons/vue/24/outline'
+
 defineProps({
     workout: { type: Object, required: true },
 })
+
+defineEmits(['clone-workout'])
 
 const getCategoryClass = (category) => {
     const classes = {

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,8 @@ use App\Http\Controllers\Admin\BookingSlotLastWorkoutResultController;
 use App\Http\Controllers\Admin\BookingSlotsController;
 use App\Http\Controllers\Admin\CancelBookingSlotController;
 use App\Http\Controllers\Admin\ChangeBookingSlotDateTimeController;
+use App\Http\Controllers\Admin\CloneBookingSlotCircuitController;
+use App\Http\Controllers\Admin\CloneBookingSlotCircuitWorkoutController;
 use App\Http\Controllers\Admin\DailyCalendarController;
 use App\Http\Controllers\Admin\FreezeBookingController;
 use App\Http\Controllers\Admin\MarkBookingAsPaidController;
@@ -135,6 +137,9 @@ Route::middleware(['auth:sanctum', config('jetstream.auth_session'), 'verified']
     Route::post('/bookings-slots/{bookingSlot}/circuits', [BookingSlotCircuitsController::class, 'store'])->name('admin.bookings-slots.circuits.store');
     Route::patch('/bookings-slots/{bookingSlot}/circuits/{circuit}', [BookingSlotCircuitsController::class, 'update'])->name('admin.bookings-slots.circuits.update');
     Route::delete('/bookings-slots/{bookingSlot}/circuits/{circuit}', [BookingSlotCircuitsController::class, 'destroy'])->name('admin.bookings-slots.circuits.destroy');
+    // Bookings slot clone
+    Route::post('/bookings-slots/{bookingSlot}/clone-circuit', CloneBookingSlotCircuitController::class)->name('admin.bookings-slots.clone-circuit');
+    Route::post('/bookings-slots/{bookingSlot}/clone-circuit-workout', CloneBookingSlotCircuitWorkoutController::class)->name('admin.bookings-slots.clone-circuit-workout');
     // Bookings slot circuit workouts
     Route::post('/bookings-slots/{bookingSlot}/circuits/{circuit}/workouts', [BookingSlotCircuitWorkoutsController::class, 'store'])->name('admin.bookings-slots.circuits.workouts.store');
     Route::put('/bookings-slots/{bookingSlot}/circuits/{circuit}/workouts/{circuitWorkout}', [BookingSlotCircuitWorkoutsController::class, 'update'])->name('admin.bookings-slots.circuits.workouts.update');

--- a/tests/Http/Admin/CloneBookingSlotCircuit/IndexTest.php
+++ b/tests/Http/Admin/CloneBookingSlotCircuit/IndexTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\BookingSlot;
+use App\Models\BookingSlotCircuit;
+
+beforeEach(function () {
+    setupUsersAndBookings();
+});
+
+test('it clones a circuit into the target booking slot', function () {
+    $targetBookingSlot = BookingSlot::query()->first();
+    $sourceCircuit = BookingSlotCircuit::factory()->create(['name' => 'Leg Day']);
+
+    actingAsAdmin()
+        ->post(route('admin.bookings-slots.clone-circuit', $targetBookingSlot), [
+            'source_circuit_id' => $sourceCircuit->id,
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect();
+});
+
+test('it requires source_circuit_id', function () {
+    $bookingSlot = BookingSlot::query()->first();
+
+    actingAsAdmin()
+        ->post(route('admin.bookings-slots.clone-circuit', $bookingSlot), [])
+        ->assertSessionHasErrors(['source_circuit_id']);
+});
+
+test('it requires authentication', function () {
+    $bookingSlot = BookingSlot::query()->first();
+    $sourceCircuit = BookingSlotCircuit::factory()->create();
+
+    $this->post(route('admin.bookings-slots.clone-circuit', $bookingSlot), [
+        'source_circuit_id' => $sourceCircuit->id,
+    ])->assertRedirect(route('login'));
+});

--- a/tests/Http/Admin/CloneBookingSlotCircuitWorkout/IndexTest.php
+++ b/tests/Http/Admin/CloneBookingSlotCircuitWorkout/IndexTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Models\BookingSlot;
+use App\Models\BookingSlotCircuit;
+use App\Models\BookingSlotCircuitWorkout;
+use App\Models\BookingSlotCircuitWorkoutSet;
+
+beforeEach(function () {
+    setupUsersAndBookings();
+});
+
+test('it clones a workout into an existing circuit', function () {
+    $targetBookingSlot = BookingSlot::query()->first();
+    $targetCircuit = BookingSlotCircuit::factory()->for($targetBookingSlot, 'bookingSlot')->create();
+    $sourceWorkout = BookingSlotCircuitWorkout::factory()->create();
+    BookingSlotCircuitWorkoutSet::factory()->weighted()->for($sourceWorkout, 'circuitWorkout')->count(2)->create();
+
+    actingAsAdmin()
+        ->post(route('admin.bookings-slots.clone-circuit-workout', $targetBookingSlot), [
+            'source_workout_id' => $sourceWorkout->id,
+            'circuit_id' => $targetCircuit->id,
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect();
+});
+
+test('it clones a workout into a new circuit when circuit_id is null', function () {
+    $targetBookingSlot = BookingSlot::query()->first();
+    $sourceWorkout = BookingSlotCircuitWorkout::factory()->create();
+    BookingSlotCircuitWorkoutSet::factory()->weighted()->for($sourceWorkout, 'circuitWorkout')->count(1)->create();
+
+    actingAsAdmin()
+        ->post(route('admin.bookings-slots.clone-circuit-workout', $targetBookingSlot), [
+            'source_workout_id' => $sourceWorkout->id,
+            'circuit_id' => null,
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect();
+});
+
+test('it requires source_workout_id', function () {
+    $bookingSlot = BookingSlot::query()->first();
+
+    actingAsAdmin()
+        ->post(route('admin.bookings-slots.clone-circuit-workout', $bookingSlot), [])
+        ->assertSessionHasErrors(['source_workout_id']);
+});
+
+test('it requires authentication', function () {
+    $bookingSlot = BookingSlot::query()->first();
+    $sourceWorkout = BookingSlotCircuitWorkout::factory()->create();
+
+    $this->post(route('admin.bookings-slots.clone-circuit-workout', $bookingSlot), [
+        'source_workout_id' => $sourceWorkout->id,
+    ])->assertRedirect(route('login'));
+});

--- a/tests/Unit/Actions/Admin/CloneBookingSlotCircuitTest.php
+++ b/tests/Unit/Actions/Admin/CloneBookingSlotCircuitTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Actions\Admin\CloneBookingSlotCircuit;
+use App\Models\BookingSlot;
+use App\Models\BookingSlotCircuit;
+use App\Models\BookingSlotCircuitWorkout;
+use App\Models\BookingSlotCircuitWorkoutSet;
+
+test('it clones a circuit with its name into the target booking slot', function () {
+    $sourceCircuit = BookingSlotCircuit::factory()->named('Push Day')->create();
+    $targetBookingSlot = BookingSlot::factory()->create();
+
+    app(CloneBookingSlotCircuit::class)->handle($sourceCircuit, $targetBookingSlot);
+
+    $this->assertDatabaseHas(BookingSlotCircuit::class, [
+        'booking_slot_id' => $targetBookingSlot->id,
+        'name' => 'Push Day',
+    ]);
+});
+
+test('it clones all workouts with their sets', function () {
+    $sourceCircuit = BookingSlotCircuit::factory()->create();
+    $workout = BookingSlotCircuitWorkout::factory()->for($sourceCircuit, 'circuit')->create(['notes' => 'Keep elbows tight']);
+    BookingSlotCircuitWorkoutSet::factory()->weighted()->for($workout, 'circuitWorkout')->count(3)->create();
+
+    $targetBookingSlot = BookingSlot::factory()->create();
+
+    app(CloneBookingSlotCircuit::class)->handle($sourceCircuit, $targetBookingSlot);
+
+    $clonedCircuit = $targetBookingSlot->circuits()->with('circuitWorkouts.sets')->first();
+
+    expect($clonedCircuit->circuitWorkouts)->toHaveCount(1)
+        ->and($clonedCircuit->circuitWorkouts->first()->notes)->toBe('Keep elbows tight')
+        ->and($clonedCircuit->circuitWorkouts->first()->sets)->toHaveCount(3);
+});
+
+test('it does not modify the source circuit', function () {
+    $sourceCircuit = BookingSlotCircuit::factory()->create();
+    $workout = BookingSlotCircuitWorkout::factory()->for($sourceCircuit, 'circuit')->create();
+    BookingSlotCircuitWorkoutSet::factory()->weighted()->for($workout, 'circuitWorkout')->count(2)->create();
+
+    $targetBookingSlot = BookingSlot::factory()->create();
+
+    app(CloneBookingSlotCircuit::class)->handle($sourceCircuit, $targetBookingSlot);
+
+    expect($sourceCircuit->fresh()->circuitWorkouts()->count())->toBe(1)
+        ->and($sourceCircuit->fresh()->circuitWorkouts()->first()->sets()->count())->toBe(2);
+});

--- a/tests/Unit/Actions/Admin/CloneBookingSlotCircuitWorkoutTest.php
+++ b/tests/Unit/Actions/Admin/CloneBookingSlotCircuitWorkoutTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Actions\Admin\CloneBookingSlotCircuitWorkout;
+use App\Models\BookingSlotCircuit;
+use App\Models\BookingSlotCircuitWorkout;
+use App\Models\BookingSlotCircuitWorkoutSet;
+
+test('it clones a workout with its sets into the target circuit', function () {
+    $sourceWorkout = BookingSlotCircuitWorkout::factory()->create(['notes' => 'Slow and controlled']);
+    BookingSlotCircuitWorkoutSet::factory()->weighted()->for($sourceWorkout, 'circuitWorkout')->count(3)->create();
+    $sourceWorkout->load('sets');
+
+    $targetCircuit = BookingSlotCircuit::factory()->create();
+
+    app(CloneBookingSlotCircuitWorkout::class)->handle($sourceWorkout, $targetCircuit);
+
+    $clonedWorkout = $targetCircuit->circuitWorkouts()->with('sets')->first();
+
+    expect($clonedWorkout)->not->toBeNull()
+        ->and($clonedWorkout->workout_id)->toBe($sourceWorkout->workout_id)
+        ->and($clonedWorkout->notes)->toBe('Slow and controlled')
+        ->and($clonedWorkout->sets)->toHaveCount(3);
+});
+
+test('it clones timed sets correctly', function () {
+    $sourceWorkout = BookingSlotCircuitWorkout::factory()->create();
+    BookingSlotCircuitWorkoutSet::factory()->timed()->for($sourceWorkout, 'circuitWorkout')->count(2)->create();
+    $sourceWorkout->load('sets');
+
+    $targetCircuit = BookingSlotCircuit::factory()->create();
+
+    app(CloneBookingSlotCircuitWorkout::class)->handle($sourceWorkout, $targetCircuit);
+
+    $clonedSets = $targetCircuit->circuitWorkouts()->first()->sets;
+
+    expect($clonedSets)->toHaveCount(2);
+    $clonedSets->each(function ($set) {
+        expect($set->duration_in_seconds)->not->toBeNull()
+            ->and($set->weight_in_kg)->toBeNull();
+    });
+});
+
+test('it does not modify the source workout', function () {
+    $sourceWorkout = BookingSlotCircuitWorkout::factory()->create();
+    BookingSlotCircuitWorkoutSet::factory()->weighted()->for($sourceWorkout, 'circuitWorkout')->count(2)->create();
+    $sourceWorkout->load('sets');
+
+    $targetCircuit = BookingSlotCircuit::factory()->create();
+
+    app(CloneBookingSlotCircuitWorkout::class)->handle($sourceWorkout, $targetCircuit);
+
+    expect($sourceWorkout->fresh()->sets()->count())->toBe(2);
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Clone booking slot circuits to other booking slots with all associated workouts and sets preserved
  * Clone individual workouts between circuits while maintaining all exercise data
  * Added "Arms" as a new category option
  * New UI controls and modals for streamlined cloning workflows

* **Tests**
  * Added comprehensive test coverage for circuit and workout cloning operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->